### PR TITLE
Mitigate for missing activesupport blank method

### DIFF
--- a/logstash-filter-cipher_kms.gemspec
+++ b/logstash-filter-cipher_kms.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'logstash-filter-cipher_kms'
-  s.version       = '0.1.2'
+  s.version       = '0.1.3'
   s.licenses      = ['Apache License (2.0)']
   s.summary       = 'This is a Logstash plugin to allow data
                       encryption/decryption using AWS KMS.'

--- a/spec/filters/cipher_kms_spec.rb
+++ b/spec/filters/cipher_kms_spec.rb
@@ -137,8 +137,14 @@ describe LogStash::Filters::CipherKms do
             'kms_cmk_id' => 'arn:aws:kms:eu-west-1:666666666666:alias/kms-key'
         }
       )
-      plain_text = 'foo'
-      event = LogStash::Event.new(LogStash::Json.load("{\"message\":\"#{plain_text}\"}"))
+      msg = {
+        message: {
+          foo: 'bar'
+        }
+      }.to_json
+
+      event = LogStash::Event.new(LogStash::Json.load(msg))
+      expect(encrypter).not_to receive(:handle_unexpected_error)
       encrypter.register
       decrypter.register
 
@@ -147,7 +153,7 @@ describe LogStash::Filters::CipherKms do
         decrypter.filter(event)
       end
 
-      expect(event.get('message')).to eq(plain_text)
+      expect(event.get('message')).to eq({ "foo" => "bar" })
     end
   end
 end


### PR DESCRIPTION
So it happens than when we removed the activesupport dependency
the blank? method in the message (usually a hash) was not longer
available (causing the condition to fail).

The reason why this was not captured in the test is that the test
were testing a payload being a string (which seems to have a blank
method implemented somewhere in logstash).

The new test verifies that if the payload is a hash (which it usually
is), then no unhandled exceptions should happen (happy path).